### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@
         <td align="center">&nbsp; 一款公告插件。 </td>
     </tr>
     <tr>
-        <td align="center"><a href="https://github.com/Coooookies/Grasscutter-MeaMailPlus">MeaMailPlus 邮件增强</a></td>
+        <td align="center"><a href="https://github.com/Zhaokugua/Grasscutter-MeaMailPlus/releases/tag/v1.0.3-fix2">MeaMailPlus 邮件增强</a></td>
         <td align="center">你可以用它来轻松的收发邮件。 </td>
     </tr>
     <tr>


### PR DESCRIPTION
替换为来自瓜瓜的修复版，目前支持到3.1暂无报错，暂未测试<a href="https://github.com/Grasscutters/Grasscutter/pull/1913">这个PR</a>是否会影响
 (tips: 请使用MeaMailPlus-1.0-SNAPSHOT.jar)

其实大部分插件已经经过gc迭代后无法使用了，应当在附属是否可用信息框。